### PR TITLE
Implement global IP and token settings in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,68 @@ npm install -g miio homebridge-mi-ir-remote
         }]
     }]
 ```
+You can also set IP and token globally so that you won't need to set it for each button.
+```
+"platforms": [
+    {
+        "platform": "ChuangmiIRPlatform",
+        "ip": "192.168.31.xx",
+        "token": "xxxxxxx",
+        "hidelearn": false,
+        "deviceCfgs": [
+            {
+                "type": "Switch",
+                "Name": "IR Switch",
+                "data": {
+                    "on" : "xxxxxxx",
+                    "off": "xxxxxxx"
+                }
+            },
+            {
+                "type": "Projector",
+                "Name": "IR Projector",
+                "interval": 1,
+                "data": {
+                    "on" : "xxxxxxxxxxxxx",
+                    "off": "xxxxxxxxxxxxx"
+                }
+            }
+        ]
+    }
+]
+```
+In case you need specific commands to go via different IR Remote Control device, you can customize IP and token inside needed command configuration. In following example IR Projector will use global IP `192.168.31.xx` and token `xxxxxxx` while IR Switch will use IP `192.168.31.zz` and token `zzzzzzz`.
+```
+"platforms": [
+    {
+        "platform": "ChuangmiIRPlatform",
+        "ip": "192.168.31.xx",
+        "token": "xxxxxxx",
+        "hidelearn": false,
+        "deviceCfgs": [
+            {
+                "type": "Switch",
+                "ip": "192.168.31.zz",
+                "token": "zzzzzzz",
+                "Name": "IR Switch",
+                "data": {
+                    "on" : "xxxxxxx",
+                    "off": "xxxxxxx"
+                }
+            },
+            {
+                "type": "Projector",
+                "Name": "IR Projector",
+                "interval": 1,
+                "data": {
+                    "on" : "xxxxxxxxxxxxx",
+                    "off": "xxxxxxxxxxxxx"
+                }
+            }
+        ]
+    }
+]
+```
 ## Get token
 Open command prompt or terminal. Run following command:
 ```
@@ -158,6 +220,8 @@ Or you can try to get Your token from any rootrd android device.
 Details in https://github.com/jghaanstra/com.xiaomi-miio/blob/master/docs/obtain_token.md
 
 ## Version Logs  
+### 0.1.1
+1. Implement global ip and token settings in config
 ### 0.1.0
 1. Rewrite the plugin and added support for both miio.Device and miio.device.
 ### 0.0.10

--- a/index.js
+++ b/index.js
@@ -55,54 +55,68 @@ function ChuangmiIRPlatform(log, config, api) {
     
 }
 
-ChuangmiIRPlatform.prototype.accessories = function(callback) {
+ChuangmiIRPlatform.prototype.accessories = function (callback) {
     var LoadedAccessories = [];
-        if(this.config['hidelearn'] == false){
-            LoadedAccessories.push(new MiRemoteirLearn(this, this.config['learnconfig']));
+    var deviceCfgs = [];
+    var deviceCfg;
+
+    if (this.config['hidelearn'] == false) {
+        this.config['learnconfig'] = this.config['learnconfig'] || [];
+        this.config['learnconfig']['type'] = 'Learn';
+        deviceCfgs.push(this.config['learnconfig']);
+    }
+
+    if (this.config['deviceCfgs'] instanceof Array) {
+        deviceCfgs = deviceCfgs.concat(this.config['deviceCfgs']);
+    }
+
+    for (var i = 0; i < deviceCfgs.length; i++) {
+        deviceCfg = deviceCfgs[i];
+
+        if (deviceCfg['ip'] == null || deviceCfg['ip'] === '' || deviceCfg['token'] == null || deviceCfg['token'] === '') {
+            deviceCfg['ip'] = this.config['ip'];
+            deviceCfg['token'] = this.config['token'];
         }
-        var deviceCfgs = this.config['deviceCfgs'];
-        
-        if(deviceCfgs instanceof Array) {
-            for (var i = 0; i < deviceCfgs.length; i++) {
-                var deviceCfg = deviceCfgs[i];
-                if(null == deviceCfg['type'] || "" == deviceCfg['type'] || null == deviceCfg['token'] || "" == deviceCfg['token'] || null == deviceCfg['ip'] || "" == deviceCfg['ip']) {
-                    continue;
-                }
 
-                switch(deviceCfg['type'])
-                {
-                    case "Switch":
-                        LoadedAccessories.push(new MiRemoteSwitch(this, deviceCfg));
-                        break;
-                    case "Light":
-                        LoadedAccessories.push(new MiRemoteLight(this, deviceCfg));
-                        break;
-                    case "Projector":
-                        LoadedAccessories.push(new MiRemoteProjector(this, deviceCfg));
-                        break;
-                    case "AirConditioner":
-                        LoadedAccessories.push(new MiRemoteAirConditioner(this, deviceCfg));
-                        break;
-                    case "Custom":
-                        LoadedAccessories.push(new MiRemoteCustom(this, deviceCfg));
-                        break;
-                    case "MomentarySwitch":
-                        LoadedAccessories.push(new MiRemoteMomentarySwitch(this, deviceCfg));
-                        break;    
-                    default:
-                        this.log.error("device type: " + deviceCfg['type'] + "Unexist!");
-                        break;
-                }
-
-                
-            }
-            this.log.info("Loaded accessories: " + LoadedAccessories.length);
+        if (deviceCfg['type'] == null || deviceCfg['type'] == ''
+            || deviceCfg['token'] == null || deviceCfg['token'] == ''
+            || deviceCfg['ip'] == null || deviceCfg['ip'] == ''
+        ) {
+            this.log.error('Device configuration incomplete');
+            continue;
         }
-        
 
-        callback(LoadedAccessories);
-}
+        switch (deviceCfg['type']) {
+            case 'Learn':
+                LoadedAccessories.push(new MiRemoteirLearn(this, deviceCfg));
+                break;
+            case 'Switch':
+                LoadedAccessories.push(new MiRemoteSwitch(this, deviceCfg));
+                break;
+            case 'Light':
+                LoadedAccessories.push(new MiRemoteLight(this, deviceCfg));
+                break;
+            case 'Projector':
+                LoadedAccessories.push(new MiRemoteProjector(this, deviceCfg));
+                break;
+            case 'AirConditioner':
+                LoadedAccessories.push(new MiRemoteAirConditioner(this, deviceCfg));
+                break;
+            case 'Custom':
+                LoadedAccessories.push(new MiRemoteCustom(this, deviceCfg));
+                break;
+            case 'MomentarySwitch':
+                LoadedAccessories.push(new MiRemoteMomentarySwitch(this, deviceCfg));
+                break;
+            default:
+                this.log.error("Device type: '" + deviceCfg['type'] + "' does not exist!");
+                break;
+        }
+    }
 
+    this.log.info('Loaded ' + LoadedAccessories.length + ' accessories');
+    callback(LoadedAccessories);
+};
 
 ChuangmiIRPlatform.prototype.getMiioDevice = function(configarray,dthat) {
     var device = "";

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-mi-ir-remote",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "ChuangMi Remote plugin for homebridge: https://github.com/nfarina/homebridge",
   "license": "GPLV3",
   "keywords": [


### PR DESCRIPTION
Here I've implemented global IP and token settings so that user doesn't need to put IP and token into each button configuration if he has only one remote control device.